### PR TITLE
fix: use turbo to run prepublish

### DIFF
--- a/packages/embed-sdk/package.json
+++ b/packages/embed-sdk/package.json
@@ -19,7 +19,7 @@
     "sigma"
   ],
   "scripts": {
-    "prepublish": "pnpm run build",
+    "prepublish": "turbo run build",
     "build": "tsup",
     "lint": "eslint . --ext .ts",
     "watch": "tsup --watch",

--- a/packages/react-embed-sdk/package.json
+++ b/packages/react-embed-sdk/package.json
@@ -20,7 +20,7 @@
     "react"
   ],
   "scripts": {
-    "prepublish": "pnpm build",
+    "prepublish": "turbo run build",
     "build": "tsup",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
We should be using turbo in the prepublish step, since its possible we want to release one package without the other