### PR TITLE
fix: relax the peer deps further

### DIFF
--- a/.changeset/smart-carrots-glow.md
+++ b/.changeset/smart-carrots-glow.md
@@ -1,0 +1,5 @@
+---
+"@sigmacomputing/react-embed-sdk": patch
+---
+
+Fix the peer deps to be more relaxed

--- a/packages/react-embed-sdk/package.json
+++ b/packages/react-embed-sdk/package.json
@@ -35,8 +35,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ^17 || ^18 || ^19",
-    "react-dom": "^16.8 || ^17 || ^18 || ^19"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@sigmacomputing/eslint-config": "workspace:*",


### PR DESCRIPTION
My previous fix did not work. I thought `^19` would allow `19.0.0-rc` but it does not? So relaxing this further to see if it would work