### PR TITLE
fix: correctly export both esm and cjs types

### DIFF
--- a/.changeset/nasty-crabs-explain.md
+++ b/.changeset/nasty-crabs-explain.md
@@ -1,0 +1,6 @@
+---
+"@sigmacomputing/react-embed-sdk": minor
+"@sigmacomputing/embed-sdk": minor
+---
+
+fix: update package.json to correctly export both cjs and esm types

--- a/packages/embed-sdk/package.json
+++ b/packages/embed-sdk/package.json
@@ -26,10 +26,18 @@
     "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "types": "./dist/index.d.ts"
+    "import": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.mts"
+    },
+    "require": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "files": [
     "dist"

--- a/packages/react-embed-sdk/package.json
+++ b/packages/react-embed-sdk/package.json
@@ -26,10 +26,18 @@
     "lint": "eslint . --ext .ts,.tsx",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "types": "./dist/index.d.ts"
+    "import": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.mts"
+    },
+    "require": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "files": [
     "dist"


### PR DESCRIPTION
Updating `tsup` revealed a warning where in some setups, `types` could be ignored by the bundlers / node. This set of exports should make types happy in _most_ scenarios. Unfortunately one scenario we don't really have a fix for is if you consume `module` and not `exports.import`, you will get the wrong types. To my knowledge, there's no tool that does this. 

This was tested using the following command: `npx --yes @arethetypeswrong/cli --pack . ` from inside `packages/embed-sdk` and `packages/react-embed-sdk`