### PR TITLE
fix: fixes the type for workbook:variables:onchange

### DIFF
--- a/.changeset/odd-hotels-cough.md
+++ b/.changeset/odd-hotels-cough.md
@@ -1,0 +1,5 @@
+---
+"@sigmacomputing/embed-sdk": minor
+---
+
+fix: fixes the variable on change type

--- a/packages/embed-sdk/src/types.ts
+++ b/packages/embed-sdk/src/types.ts
@@ -109,7 +109,9 @@ export interface WorkbookErrorEvent {
 
 export interface WorkbookVariableOnChangeEvent {
   type: typeof WorkbookVariableEventOnChangeName;
-  variables: Record<string, string>;
+  workbook: {
+    variables: Record<string, string>;
+  };
 }
 
 export interface WorkbookVariableCurrentEvent {


### PR DESCRIPTION
Fixes #68

Changes the type for `workbook:variables:onchange` to match what we list in our docs: https://help.sigmacomputing.com/docs/inbound-and-outbound-events-in-embeds#workbookloaded

Verified this is what we send out in app. 