### PR TITLE
Add copyright year to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Sigma Computing Inc.
+Copyright (c) 2026 Sigma Computing Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Add `2026` to the copyright notice in `LICENSE`

## Test plan
- [x] Verify LICENSE diff shows only the year addition

https://claude.ai/code/session_01CXgzAB6Ws5ZiPnaKJ9d4Vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXgzAB6Ws5ZiPnaKJ9d4Vf)_